### PR TITLE
Throw on HTTP errors from call endpoint

### DIFF
--- a/src/components/PrimVoicesProviderContext.tsx
+++ b/src/components/PrimVoicesProviderContext.tsx
@@ -116,11 +116,14 @@ export const PrimVoicesProvider: React.FC<PrimVoicesProviderProps> = ({
     if (clientRef.current) {
       try {
         await clientRef.current.connect();
-      } catch (err) {
-        setError('Failed to connect');
+      } catch (err: any) {
+        const message = err?.message || 'Failed to connect';
+        setError(message);
+        throw err;
       }
     } else {
       setError('Client not initialized');
+      throw new Error('Client not initialized');
     }
   };
 

--- a/src/utils/WebSocketClient.ts
+++ b/src/utils/WebSocketClient.ts
@@ -180,6 +180,11 @@ export class WebSocketClient {
       body: JSON.stringify({}),
     });
 
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || `Request failed with status ${response.status}`);
+    }
+
     const responseJson = await response.json();
 
     return responseJson.data;


### PR DESCRIPTION
getAgentConfiguration() now checks response.ok and throws with the server error message (e.g. 402 insufficient credits). The provider context re-throws so consumers can catch and display the error.